### PR TITLE
Add :string_keys_to_atoms option

### DIFF
--- a/lib/util/deep_new.ex
+++ b/lib/util/deep_new.ex
@@ -14,6 +14,9 @@ defmodule Util.Proto do
   parameters.
 
   Options filed parameters:
+  - string_keys_to_atoms:
+    If value of this field is true, any Map key which is string in passed arguments
+    map and all nested maps will be automatically transformed into atom.
   - transformations:
      Map where keys should be module names, and values user provided
      functions, given either as annonymous functions or tuple
@@ -94,6 +97,13 @@ defmodule Util.Proto do
     args |> Enum.map(&init_property(struct, &1, opts))
   end
 
+  defp init_property(struct, {name, value}, opts) when is_binary(name)  do
+    if Keyword.get(opts, :string_keys_to_atoms, false) do
+      init_property(struct, {String.to_atom(name), value}, opts)
+    else
+      {name, value}
+    end
+  end
   defp init_property(struct, {name, value}, opts) do
     props = struct |> apply(:__message_props__, [])
     props

--- a/test/proto_test.exs
+++ b/test/proto_test.exs
@@ -128,4 +128,17 @@ defmodule Util.ProtoTest do
     assert Util.Proto.deep_new(SimpleProto, %{bool_value: 12}) ==
       {:error, %RuntimeError{message: "Field: 'bool_value': Expected boolean argument, got '12'"}}
   end
+
+  test "string_keys_to_atoms" do
+    assert %NestedProto{simple_proto: simple_proto, rsp: rsp} =
+      Util.Proto.deep_new!(
+         NestedProto,
+         %{"simple_proto" => %{"int_value" => 3, "bool_value" => true}, "rsp" => [%{string_value: "test"}]},
+         string_keys_to_atoms: true)
+
+     assert simple_proto == %SimpleProto{
+       bool_value: true, int_value: 3, string_value: "", float_value: 0, repeated_string: []}
+     assert rsp == [%SimpleProto{
+       bool_value: false, int_value: 0, string_value: "test", float_value: 0, repeated_string: []}]
+  end
 end


### PR DESCRIPTION
Useful for maps that are read from `jsonb` fields, because their keys are strings by default.