### PR TITLE
Proto.to_map() returns {:ok, map} only when struct is given

### DIFF
--- a/lib/util/proto.ex
+++ b/lib/util/proto.ex
@@ -59,7 +59,9 @@ defmodule Util.Proto do
     e -> {:error, e}
   end
 
-  def to_map!(proto, opts \\ []), do: decode_value(proto, opts)
+  def to_map!(proto, opts \\ [])
+  def to_map!(proto = %{__struct__: _}, opts), do: decode_value(proto, opts)
+  def to_map!(proto, _opts), do: raise("Not a valid Proto struct: #{inspect proto}")
 
   defp decode_value(%struct{} = value, opts) do
     decoded_value = value |> Map.from_struct |> decode_value(opts)

--- a/test/proto_test.exs
+++ b/test/proto_test.exs
@@ -152,6 +152,10 @@ defmodule Util.ProtoTest do
        bool_value: false, int_value: 0, string_value: "test", float_value: 0, repeated_string: []}]
   end
 
+  test "to_map - error when something other then struct is passed" do
+    assert("123" |> Util.Proto.to_map == {:error, %RuntimeError{message: "Not a valid Proto struct: \"123\""}})
+  end
+
   test "EnumProto to_map - no args" do
     assert(TestHelpers.EnumProto.new |> Util.Proto.to_map! == %{code: :OK, codes: []})
   end


### PR DESCRIPTION
Maybe it should return :ok for plain maps also, but current behavior when :ok is returned in every case is surely wrong.