### PR TITLE
deep_new functions should receive proto arguments as first arg

### DIFF
--- a/lib/util/proto.ex
+++ b/lib/util/proto.ex
@@ -4,9 +4,9 @@ defmodule Util.Proto do
   structures defined by protobuf-elixir modules.
 
   Usage:
-    iex> Util.Proto.deep_new!(module, arguments, options)
-    - module    - [required] Name of module which contains Protobuf structure definition
+    iex> Util.Proto.deep_new!(arguments, module, options)
     - arguments - [required] Plain elixir map with actual values for stucture fields
+    - module    - [required] Name of module which contains Protobuf structure definition
     - options   - [optional] Keyword containing optional parameters. More details below.
 
   Function will iterate ower passed arguments, recursively initialize any non-basic
@@ -35,14 +35,26 @@ defmodule Util.Proto do
   @proto_basic_types ~w(bool string enum int32 int64 uint32 uint64 sint32 sint64
    fixed32 fixed64 sfixed32 sfixed64 float double)a
 
-  def deep_new(struct, args, opts \\ []) do
+  def deep_new(_, _, opts \\ [])
+
+  def deep_new(args, struct, opts) when is_atom(struct) and is_map(args) do
+    deep_new(struct, args, opts)
+  end
+
+  def deep_new(struct, args, opts) do
     {:ok, deep_new!(struct, args, opts)}
   rescue
     e ->
       {:error, e}
   end
 
-  def deep_new!(struct, args, opts \\ []), do: do_deep_new(args, struct, "", opts)
+  def deep_new!(_, _, opts \\ [])
+
+  def deep_new!(args, struct, opts) when is_atom(struct) and is_map(args) do
+    deep_new!(struct, args, opts)
+  end
+
+  def deep_new!(struct, args, opts), do: do_deep_new(args, struct, "", opts)
 
 
 ######################

--- a/test/proto_test.exs
+++ b/test/proto_test.exs
@@ -4,6 +4,11 @@ defmodule Util.ProtoTest do
 
   alias TestHelpers.{SimpleProto, NestedProto, EnumProto, NestedEnumProto}
 
+  test "simple test - no args - args first" do
+    assert %{} |> Util.Proto.deep_new!(SimpleProto) ==
+      %SimpleProto{bool_value: false, int_value: 0, string_value: "",
+        float_value: 0, repeated_string: []}
+  end
 
   test "simple test - no args" do
     assert Util.Proto.deep_new!(SimpleProto, %{}) ==
@@ -63,11 +68,23 @@ defmodule Util.ProtoTest do
     assert rsp == []
   end
 
+  test "nested test - SimpleProto field - non empty map, non empty list - args first" do
+    assert %NestedProto{simple_proto: simple_proto, rsp: rsp} =
+      %{simple_proto: %{int_value: 3}, rsp: [%{bool_value: true}]}
+      |> Util.Proto.deep_new!(NestedProto)
+
+      simple_proto_non_empty_assert(simple_proto, rsp)
+  end
+
   test "nested test - SimpleProto field - non empty map, non empty list" do
     assert %NestedProto{simple_proto: simple_proto, rsp: rsp} =
       Util.Proto.deep_new!(
         NestedProto, %{simple_proto: %{int_value: 3}, rsp: [%{bool_value: true}]})
 
+    simple_proto_non_empty_assert(simple_proto, rsp)
+  end
+
+  defp simple_proto_non_empty_assert(simple_proto, rsp) do
     assert simple_proto == %SimpleProto{
       bool_value: false, int_value: 3, string_value: "", float_value: 0, repeated_string: []}
     assert rsp == [%SimpleProto{


### PR DESCRIPTION
Backward compatible change that allows chaining ('|>').
First two function arguments can swap positions, so that proto args are fist.